### PR TITLE
Version lock fastapi version due to issue with fastapi-pagination dependency

### DIFF
--- a/server/app/requirements.txt
+++ b/server/app/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi==0.96.0
 fastapi-pagination
 geopandas
 pandas


### PR DESCRIPTION
Workaround until fixed by fastapi.

See issue description here:
https://github.com/FHNW-IVGI/Geoharvester/issues/87