### PR TITLE
Bugfixes: Qgis export, Special chars

### DIFF
--- a/client/src/components/table/SubRow.tsx
+++ b/client/src/components/table/SubRow.tsx
@@ -45,6 +45,8 @@ export const SubRow = ({
         "endpoint",
       ];
 
+  const NULLVALUES = ["", "nan", "n.a", null];
+
   const routeObjectBuilder = () => {
     if (!row || !row.service) {
       return {
@@ -151,11 +153,7 @@ export const SubRow = ({
                               : row.preview;
                           window.open(url);
                         }}
-                        disabled={
-                          row.preview === "n.a." ||
-                          row.preview === null ||
-                          row.preview === ""
-                        }
+                        disabled={NULLVALUES.includes(row.preview)}
                       >
                         Service in MapGeo öffnen
                       </Button>
@@ -177,11 +175,7 @@ export const SubRow = ({
                         <Button
                           onClick={() => window.open(row.legend)}
                           style={{ padding: 0 }}
-                          disabled={
-                            row.legend === "n.a." ||
-                            row.legend === null ||
-                            row.legend === ""
-                          }
+                          disabled={NULLVALUES.includes(row.legend)}
                         >
                           Legende öffnen
                         </Button>
@@ -203,6 +197,7 @@ export const SubRow = ({
                         }}
                         onClick={routeObjectBuilder().arcgis_handler}
                         startIcon={<DownloadIcon />}
+                        disabled={NULLVALUES.includes(row.endpoint)}
                       >
                         For ArcGIS Pro
                       </Button>
@@ -210,6 +205,7 @@ export const SubRow = ({
                         variant="outlined"
                         onClick={routeObjectBuilder().qgis_handler}
                         startIcon={<DownloadIcon />}
+                        disabled={NULLVALUES.includes(row.endpoint)}
                       >
                         For QGIS
                       </Button>

--- a/client/src/templateParser/qgisParser.ts
+++ b/client/src/templateParser/qgisParser.ts
@@ -7,8 +7,7 @@ export const parseQgisTemplate = async (data: Geoservice, response: any) => {
     const ymin = bboxArray[1];
     const xmax = bboxArray[2];
     const ymax = bboxArray[3];
-    const urlParts = data.endpoint.split("/")
-    const serviceSnippet = `${urlParts[0]}//${urlParts[2]}/`.trim()
+    const serviceSnippet = data.endpoint.trim()
     projectXml = projectXml.replace("{{endpoint}}", serviceSnippet);
     projectXml = projectXml.replace("{{name}}", data.name);
     projectXml = projectXml.replace("{{name}}", data.name);

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import re
 import warnings
 from time import time
 from typing import Union
@@ -134,7 +135,7 @@ async def get_data(query_string: Union[str, None] = None,  service: EnumServiceT
         word_list = split_search_string(query_string)
         language_dict = {'en': 'english', 'fr': 'french', 'de': 'german', 'it': 'italian'}
         stop_words = stopwords.words(language_dict[lang])
-        word_list_clean = [word for word in word_list if word not in stop_words]
+        word_list_clean = [re.escape(word) for word in word_list if word not in stop_words] # Escape all special chars except _, otherwise Redis throws error
         text_query = transform_wordlist_to_query(word_list_clean, lang)
 
         redis_query = redis_query_from_parameters(text_query, service, provider)


### PR DESCRIPTION
## Changes:
- Use endpoint url for qgis-export (this will still fail if that url is not valid, due to mistake on provider side)
- Escape special chars before redis query. This will result in "no results" instead of "error", unless dataset name matches